### PR TITLE
Fix: Contact name capitalization and birthday validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ __marimo__/
 addressbook.pkl
 draft.py
 notes.pkl
+
+# MacOS
+.DS_Store

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import date, datetime
 from tabulate import tabulate
 from colorama import Fore, Style, init
 
@@ -20,15 +20,15 @@ def is_valid_phone(phone):
 
 def is_valid_birthday(birthday_str: str) -> bool:
     try:
-        datetime.strptime(birthday_str, "%Y-%m-%d")
-        return True
+        bday = datetime.strptime(birthday_str, "%Y-%m-%d").date()
+        return bday <= date.today()
     except ValueError:
         return False
 
 
 @input_error
 def add_contact(_, contact_book: ContactBook):
-    name = input(f"{Fore.CYAN}Name:{Style.RESET_ALL} ").strip()
+    name = input(f"{Fore.CYAN}Name:{Style.RESET_ALL} ").strip().title()
     if not name:
         raise ValueError("Name is required.")
 
@@ -41,9 +41,14 @@ def add_contact(_, contact_book: ContactBook):
         raise ValueError("Invalid email address")
 
     address = input(f"{Fore.CYAN}Address (optional):{Style.RESET_ALL} ").strip()
-    birthday = input(f"{Fore.CYAN}Birthday (YYYY-MM-DD, optional):{Style.RESET_ALL} ").strip()
-    if birthday and not is_valid_birthday(birthday):
-        raise ValueError("Invalid birthday. Use YYYY-MM-DD")
+    birthday = ""
+    while True:
+        birthday = input(f"{Fore.CYAN}Birthday (YYYY-MM-DD):{Style.RESET_ALL} ").strip()
+        if not birthday:
+            break  # Birthday is optional
+        if is_valid_birthday(birthday):
+            break
+        print(f"{Fore.RED}Invalid birthday. Please use YYYY-MM-DD and ensure the date is not in the future.{Style.RESET_ALL}")
 
     contact = Contact(name, phone, email, address, birthday)
     success = contact_book.add_contact(contact)
@@ -88,6 +93,22 @@ def edit_contact(_, contact_book: ContactBook):
     name = input(f"{Fore.CYAN}Contact name to edit:{Style.RESET_ALL} ").strip()
     field = input(f"{Fore.CYAN}Field to edit (name, phone, email, address, birthday):{Style.RESET_ALL} ").strip()
     value = input(f"{Fore.CYAN}New value for {field}:{Style.RESET_ALL} ").strip()
+
+    if field == "name":
+        value = value.title()
+        contact = contact_book.find(name)
+        if contact:
+            contact_book.delete_contact(name)
+            contact.name = value
+            contact_book.add_contact(contact)
+            return f"{Fore.GREEN}Contact renamed to '{value}'.{Style.RESET_ALL}"
+        else:
+            return f"{Fore.RED}Contact '{name}' not found.{Style.RESET_ALL}"
+
+    elif field == "birthday":
+        while not is_valid_birthday(value):
+            print(f"{Fore.RED}Invalid birthday. Please use YYYY-MM-DD and ensure the date is not in the future.{Style.RESET_ALL}")
+            value = input(f"{Fore.CYAN}New value for {field}:{Style.RESET_ALL} ").strip()
 
     success = contact_book.edit_contact(name, **{field: value})
     return (


### PR DESCRIPTION
This PR fixes two issues related to contact data validation and formatting:

1. Contact name normalization:
   - All contact names are now automatically converted to title case (e.g., "john doe" → "John Doe") during both creation and renaming.
   - Prevents duplicate contacts with differently-cased names (e.g., "ivan" == "Ivan").

2. Birthday input validation:
   - Ensures birthdays cannot be set to future dates.
   - Users are prompted to re-enter a birthday if it's in the wrong format or in the future (in both add and edit operations).